### PR TITLE
Instructions on how to use `OvyFlash/telegram-bot-api` by replacing the original dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-# Golang bindings for the Telegram Bot API
+> # Usage
+> If you want to use this fork in the project that imports the original repo, the easiest way is to:
+> - `git submodule add git@github.com:OvyFlash/telegram-bot-api.git telegram-bot-api`
+> - `go mod edit --replace github.com/go-telegram-bot-api/telegram-bot-api/v5=./telegram-bot-api/`
+> - `go mod tidy`
+> And you're ready to go.
+> Notice, that there have been several breaking changes since the telegram bot API v5 was released, so you might need to update your application.
 
+# Golang bindings for the Telegram Bot API
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-telegram-bot-api/telegram-bot-api/v5.svg)](https://pkg.go.dev/github.com/go-telegram-bot-api/telegram-bot-api/v5)
 [![Test](https://github.com/go-telegram-bot-api/telegram-bot-api/actions/workflows/test.yml/badge.svg)](https://github.com/go-telegram-bot-api/telegram-bot-api/actions/workflows/test.yml)
 


### PR DESCRIPTION
You may not merge it, but let it hang for those, who are willing to use up-to-date lib.

---

# Usage
If you want to use this fork in the project that imports the original repo, the easiest way is to:
- `git submodule add git@github.com:OvyFlash/telegram-bot-api.git telegram-bot-api` or download the sources into the target directory.
- `go mod edit --replace github.com/go-telegram-bot-api/telegram-bot-api/v5=./telegram-bot-api/`
- `go mod tidy`
And you're ready to go.
Notice, that there have been several breaking changes since the telegram bot API v5 was released, so you might need to update your application.