### PR TITLE
Added NewDeleteMessages function

### DIFF
--- a/helper_methods.go
+++ b/helper_methods.go
@@ -40,6 +40,19 @@ func NewDeleteMessage(chatID int64, messageID int) DeleteMessageConfig {
 	}
 }
 
+// NewDeleteMessages creates a request to delete multiple messages. The messages have to be
+// in the same chat. Provide the message ids as an array of integers
+func NewDeleteMessages(chatID int64, messageIDs []int) DeleteMessagesConfig {
+	return DeleteMessagesConfig{
+		BaseChatMessages: BaseChatMessages{
+			ChatConfig: ChatConfig{
+				ChatID: chatID,
+			},
+			MessageIDs: messageIDs,
+		},
+	}
+}
+
 // NewMessageToChannel creates a new Message that is sent to a channel
 // by username.
 //


### PR DESCRIPTION
Can be used to batch DeleteMessage requests for the same chat. Use it calling NewDeleteMessages with the ChatID and an array of integers containing the message IDs, then pass the returned `DeleteMessagesConfig` to bot.Request(object).