### PR TITLE
fix ReplyToMessageID assignment in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ func main() {
 			log.Printf("[%s] %s", update.Message.From.UserName, update.Message.Text)
 
 			msg := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
-			msg.ReplyToMessageID = update.Message.MessageID
+			msg.ReplyParameters.MessageID = update.Message.MessageID
 
 			bot.Send(msg)
 		}


### PR DESCRIPTION
for compatibility with 7.0 api

In https://github.com/OvyFlash/telegram-bot-api/pull/12/files msg.ReplyToMessageID was moved to msg.ReplyParameters.MessageID

This PR updates a readme example