### PR TITLE
Fix missing ParseMode in InlineQueryResultVideo

### DIFF
--- a/types.go
+++ b/types.go
@@ -4406,9 +4406,15 @@ type InlineQueryResultVideo struct {
 	//
 	// optional
 	Caption string `json:"caption,omitempty"`
-	// Width video width
+	// ParseMode mode for parsing entities in the video caption.
+	// See formatting options for more details
+	// (https://core.telegram.org/bots/api#formatting-options).
 	//
 	// optional
+	ParseMode string `json:"parse_mode,omitempty"`
+	// Width video width
+	//
+	// optional	
 	Width int `json:"video_width,omitempty"`
 	// Height video height
 	//
@@ -4448,7 +4454,7 @@ type InlineQueryResultVoice struct {
 	//
 	// optional
 	Caption string `json:"caption,omitempty"`
-	// ParseMode mode for parsing entities in the video caption.
+	// ParseMode mode for parsing entities in the voice caption.
 	// See formatting options for more details
 	// (https://core.telegram.org/bots/api#formatting-options).
 	//


### PR DESCRIPTION
ParseMode for this type actually exists, but was missed in the original repo. https://core.telegram.org/bots/api#inlinequeryresultvideo