### PR TITLE
Add required "SuggestedTipAmounts" field in NewInvoice

### DIFF
--- a/helper_methods.go
+++ b/helper_methods.go
@@ -834,18 +834,20 @@ func NewCallbackWithAlert(id, text string) CallbackConfig {
 }
 
 // NewInvoice creates a new Invoice request to the user.
-func NewInvoice(chatID int64, title, description, payload, providerToken, startParameter, currency string, prices []LabeledPrice) InvoiceConfig {
+func NewInvoice(chatID int64, title, description, payload, providerToken, startParameter, currency string, prices []LabeledPrice, suggestedTipAmounts []int) InvoiceConfig {
 	return InvoiceConfig{
 		BaseChat: BaseChat{
 			ChatConfig: ChatConfig{ChatID: chatID},
 		},
-		Title:          title,
-		Description:    description,
-		Payload:        payload,
-		ProviderToken:  providerToken,
-		StartParameter: startParameter,
-		Currency:       currency,
-		Prices:         prices}
+		Title:               title,
+		Description:         description,
+		Payload:             payload,
+		ProviderToken:       providerToken,
+		StartParameter:      startParameter,
+		Currency:            currency,
+		Prices:              prices,
+		SuggestedTipAmounts: suggestedTipAmounts,
+	}
 }
 
 // NewChatTitle allows you to update the title of a chat.


### PR DESCRIPTION
## Before change
The following handler:
```go
func HandleDebug(bot *tgbotapi.BotAPI, update tgbotapi.Update) {
	prices := []tgbotapi.LabeledPrice{{Label: "Stars", Amount: 500}}
	msg := tgbotapi.NewInvoice(update.FromChat().ID, "Test", "A simple test invoice", "payload", "", "", "XTR", prices)
	bot.Send(msg)
}
```

Produced this output when called:
> 2024/07/21 17:08:38 Endpoint: sendInvoice, params: map[business_connection_id: chat_id:128985103 currency:XTR description:A simple test invoice payload:payload prices:[{"label":"Stars","amount":500}] reply_parameters:{"message_id":0} suggested_tip_amounts:null title:Test]
> 2024/07/21 17:08:38 Endpoint: sendInvoice, response: {"ok":false,"error_code":400,"description":"Bad Request: expected an Array of suggested tip amounts"}