### PR TITLE
Added the ability to call the createInvoiceLink() method to generate …

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -671,6 +671,23 @@ func (bot *BotAPI) GetInviteLink(config ChatInviteLinkConfig) (string, error) {
 	return inviteLink, err
 }
 
+// CreateInvoiceLink Use this method to create a link for an invoice. Returns the created invoice link as
+// String on success.
+func (bot *BotAPI) CreateInvoiceLink(config InvoiceLinkConfig) (inviteLink string, err error) {
+	var resp *APIResponse
+
+	if resp, err = bot.Request(config); err != nil {
+		return
+	}
+	if !resp.Ok {
+		err = fmt.Errorf("returns error code: %d", resp.ErrorCode)
+		return
+	}
+	err = json.Unmarshal(resp.Result, &inviteLink)
+
+	return
+}
+
 // GetStickerSet returns a StickerSet.
 func (bot *BotAPI) GetStickerSet(config GetStickerSetConfig) (StickerSet, error) {
 	resp, err := bot.Request(config)

--- a/helper_methods.go
+++ b/helper_methods.go
@@ -834,7 +834,23 @@ func NewCallbackWithAlert(id, text string) CallbackConfig {
 }
 
 // NewInvoice creates a new Invoice request to the user.
-func NewInvoice(chatID int64, title, description, payload, providerToken, startParameter, currency string, prices []LabeledPrice, suggestedTipAmounts []int) InvoiceConfig {
+func NewInvoice(
+	chatID int64,
+	title string,
+	description string,
+	payload string,
+	providerToken string,
+	startParameter string,
+	currency string,
+	prices []LabeledPrice,
+	suggestedTipAmounts []int,
+) InvoiceConfig {
+	var maxTipAmount, n int
+	for n = range suggestedTipAmounts {
+		if maxTipAmount < suggestedTipAmounts[n] {
+			maxTipAmount = suggestedTipAmounts[n]
+		}
+	}
 	return InvoiceConfig{
 		BaseChat: BaseChat{
 			ChatConfig: ChatConfig{ChatID: chatID},
@@ -847,6 +863,21 @@ func NewInvoice(chatID int64, title, description, payload, providerToken, startP
 		Currency:            currency,
 		Prices:              prices,
 		SuggestedTipAmounts: suggestedTipAmounts,
+		MaxTipAmount:        maxTipAmount,
+	}
+}
+
+// NewInvoiceLink creates a new createInvoiceLink request.
+func NewInvoiceLink(ico InvoiceConfig) InvoiceLinkConfig {
+	return InvoiceLinkConfig{
+		Title:               ico.Title,
+		Description:         ico.Description,
+		Payload:             ico.Payload,
+		ProviderToken:       ico.ProviderToken,
+		Currency:            ico.Currency,
+		Prices:              ico.Prices,
+		SuggestedTipAmounts: ico.SuggestedTipAmounts,
+		MaxTipAmount:        ico.MaxTipAmount,
 	}
 }
 


### PR DESCRIPTION
…a link to invoice for the telegram mini app.

[createInvoiceLink()](https://core.telegram.org/bots/api#createinvoicelink)
Use this method to create a link for an invoice. Returns the created invoice link as String on success.