### PR TITLE
Add extra edit message media types

### DIFF
--- a/helper_methods.go
+++ b/helper_methods.go
@@ -227,6 +227,14 @@ func NewMediaGroup(chatID int64, files []interface{}) MediaGroupConfig {
 	}
 }
 
+// NewBaseInputMedia creates a new BaseInputMedia.
+func NewBaseInputMedia(mediaType string, media RequestFileData) BaseInputMedia {
+	return BaseInputMedia{
+		Type:  mediaType,
+		Media: media,
+	}
+}
+
 // NewInputMediaPhoto creates a new InputMediaPhoto.
 func NewInputMediaPhoto(media RequestFileData) InputMediaPhoto {
 	return InputMediaPhoto{
@@ -605,6 +613,46 @@ func NewInlineQueryResultVenue(id, title, address string, latitude, longitude fl
 		Latitude:  latitude,
 		Longitude: longitude,
 	}
+}
+
+// NewEditMessageMedia allows you to edit the media content of a message.
+func NewEditMessageMedia(chatID int64, messageID int, inputMedia interface{}) EditMessageMediaConfig {
+	return EditMessageMediaConfig{
+		BaseEdit: BaseEdit{
+			BaseChatMessage: BaseChatMessage{
+				ChatConfig: ChatConfig{
+					ChatID: chatID,
+				},
+				MessageID: messageID,
+			},
+		},
+		Media: inputMedia,
+	}
+}
+
+// NewEditMessagePhoto allows you to edit the photo content of a message.
+func NewEditMessagePhoto(chatID int64, messageID int, inputPhoto InputMediaPhoto) EditMessageMediaConfig {
+	return NewEditMessageMedia(chatID, messageID, inputPhoto)
+}
+
+// NewEditMessageVideo allows you to edit the video content of a message.
+func NewEditMessageVideo(chatID int64, messageID int, inputVideo InputMediaVideo) EditMessageMediaConfig {
+	return NewEditMessageMedia(chatID, messageID, inputVideo)
+}
+
+// NewEditMessageAnimation allows you to edit the animation content of a message.
+func NewEditMessageAnimation(chatID int64, messageID int, inputAnimation InputMediaAnimation) EditMessageMediaConfig {
+	return NewEditMessageMedia(chatID, messageID, inputAnimation)
+}
+
+// NewEditMessageAudio allows you to edit the audio content of a message.
+func NewEditMessageAudio(chatID int64, messageID int, inputAudio InputMediaAudio) EditMessageMediaConfig {
+	return NewEditMessageMedia(chatID, messageID, inputAudio)
+}
+
+// NewEditMessageDocument allows you to edit the document content of a message.
+func NewEditMessageDocument(chatID int64, messageID int, inputDocument InputMediaDocument) EditMessageMediaConfig {
+	return NewEditMessageMedia(chatID, messageID, inputDocument)
 }
 
 // NewEditMessageText allows you to edit the text of a message.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -197,6 +197,84 @@ func TestNewInlineKeyboardButtonSwitchInlineQueryChoosenChat(t *testing.T) {
 	}
 }
 
+func TestNewEditMessageMedia(t *testing.T) {
+	baseInputMedia := NewBaseInputMedia("photo", FileID("test"))
+	edit := NewEditMessageMedia(ChatID, ReplyToMessageID, baseInputMedia)
+
+	if edit.Media == nil ||
+		edit.Media.(BaseInputMedia).Type != "photo" ||
+		edit.Media.(BaseInputMedia).Media != baseInputMedia.Media ||
+		edit.BaseEdit.ChatID != ChatID ||
+		edit.BaseEdit.MessageID != ReplyToMessageID {
+		t.Fail()
+	}
+}
+
+func TestNewEditMessagePhoto(t *testing.T) {
+	inputMediaPhoto := NewInputMediaPhoto(FilePath("tests/image.jpg"))
+	edit := NewEditMessagePhoto(ChatID, ReplyToMessageID, inputMediaPhoto)
+
+	if edit.Media == nil ||
+		edit.Media.(InputMediaPhoto).Type != "photo" ||
+		edit.Media.(InputMediaPhoto).Media != inputMediaPhoto.Media ||
+		edit.BaseEdit.ChatID != ChatID ||
+		edit.BaseEdit.MessageID != ReplyToMessageID {
+		t.Fail()
+	}
+}
+
+func TestNewEditMessageVideo(t *testing.T) {
+	inputMediaVideo := NewInputMediaVideo(FilePath("tests/video.mp4"))
+	edit := NewEditMessageVideo(ChatID, ReplyToMessageID, inputMediaVideo)
+
+	if edit.Media == nil ||
+		edit.Media.(InputMediaVideo).Type != "video" ||
+		edit.Media.(InputMediaVideo).Media != inputMediaVideo.Media ||
+		edit.BaseEdit.ChatID != ChatID ||
+		edit.BaseEdit.MessageID != ReplyToMessageID {
+		t.Fail()
+	}
+}
+
+func TestNewEditMessageAnimation(t *testing.T) {
+	inputMediaAnimation := NewInputMediaAnimation(FileID("test"))
+	edit := NewEditMessageAnimation(ChatID, ReplyToMessageID, inputMediaAnimation)
+
+	if edit.Media == nil ||
+		edit.Media.(InputMediaAnimation).Type != "animation" ||
+		edit.Media.(InputMediaAnimation).Media != inputMediaAnimation.Media ||
+		edit.BaseEdit.ChatID != ChatID ||
+		edit.BaseEdit.MessageID != ReplyToMessageID {
+		t.Fail()
+	}
+}
+
+func TestNewEditMessageAudio(t *testing.T) {
+	inputMediaAudio := NewInputMediaAudio(FileID("test"))
+	edit := NewEditMessageAudio(ChatID, ReplyToMessageID, inputMediaAudio)
+
+	if edit.Media == nil ||
+		edit.Media.(InputMediaAudio).Type != "audio" ||
+		edit.Media.(InputMediaAudio).Media != inputMediaAudio.Media ||
+		edit.BaseEdit.ChatID != ChatID ||
+		edit.BaseEdit.MessageID != ReplyToMessageID {
+		t.Fail()
+	}
+}
+
+func TestNewEditMessageDocument(t *testing.T) {
+	inputMediaDocument := NewInputMediaDocument(FileID("test"))
+	edit := NewEditMessageDocument(ChatID, ReplyToMessageID, inputMediaDocument)
+
+	if edit.Media == nil ||
+		edit.Media.(InputMediaDocument).Type != "document" ||
+		edit.Media.(InputMediaDocument).Media != inputMediaDocument.Media ||
+		edit.BaseEdit.ChatID != ChatID ||
+		edit.BaseEdit.MessageID != ReplyToMessageID {
+		t.Fail()
+	}
+}
+
 func TestNewEditMessageText(t *testing.T) {
 	edit := NewEditMessageText(ChatID, ReplyToMessageID, "new text")
 


### PR DESCRIPTION
Library doesn't support editing [all supported media types](https://core.telegram.org/bots/api#inputmedia) at the moment.

This PR expands code capabilities in this way:

Added 6 new config types to edit media messages:

1. `NewEditMessageMedia` - base method to edit media messages
2. `NewEditMessagePhoto` - to edit messages with the `photo` type
3. `NewEditMessageVideo` - to edit messages with the `video` type
4. `NewEditMessageAnimation` - to edit messages with the `animation` type
5. `NewEditMessageAudio` - to edit messages with the `audio` type
6. `NewEditMessageDocument` - to edit messages with the `document` type