### PR TITLE
Fix sendDocument caption_entities param

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -560,6 +560,10 @@ func (config DocumentConfig) params() (Params, error) {
 	params.AddNonEmpty("caption", config.Caption)
 	params.AddNonEmpty("parse_mode", config.ParseMode)
 	params.AddBool("disable_content_type_detection", config.DisableContentTypeDetection)
+	err = params.AddInterface("caption_entities", config.CaptionEntities)
+	if err != nil {
+		return params, err
+	}
 
 	return params, err
 }


### PR DESCRIPTION
At the moment document caption formatting is not working because library doesn't send `caption_entities` param to `sendDocument`. This PR fixes it.