### PR TITLE
Make it go-gettable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.15
+        go-version: "1.23"
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build
       run: go build -v .

--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
-> # Usage
-> If you want to use this fork in the project that imports the original repo, the easiest way is to:
-> - `git submodule add git@github.com:OvyFlash/telegram-bot-api.git telegram-bot-api`
-> - `go mod edit --replace github.com/go-telegram-bot-api/telegram-bot-api/v5=./telegram-bot-api/`
-> - `go mod tidy`
-> And you're ready to go.
-> Notice, that there have been several breaking changes since the telegram bot API v5 was released, so you might need to update your application.
-
 # Golang bindings for the Telegram Bot API
-[![Go Reference](https://pkg.go.dev/badge/github.com/go-telegram-bot-api/telegram-bot-api/v5.svg)](https://pkg.go.dev/github.com/go-telegram-bot-api/telegram-bot-api/v5)
+[![Go Reference](https://pkg.go.dev/badge/github.com/OvyFlash/telegram-bot-api/v6.svg)](https://pkg.go.dev/github.com/OvyFlash/telegram-bot-api/v6)
 [![Test](https://github.com/go-telegram-bot-api/telegram-bot-api/actions/workflows/test.yml/badge.svg)](https://github.com/go-telegram-bot-api/telegram-bot-api/actions/workflows/test.yml)
 
-All methods are fairly self-explanatory, and reading the [godoc](https://pkg.go.dev/github.com/go-telegram-bot-api/telegram-bot-api/v5) page should
+All methods are fairly self-explanatory, and reading the [godoc](https://pkg.go.dev/github.com/OvyFlash/telegram-bot-api/v6) page should
 explain everything. If something isn't clear, open an issue or submit
 a pull request.
 
@@ -27,7 +19,7 @@ you want to ask questions or discuss development.
 ## Example
 
 First, ensure the library is installed and up to date by running
-`go get -u github.com/go-telegram-bot-api/telegram-bot-api/v5`.
+`go get -u github.com/OvyFlash/telegram-bot-api/v6`.
 
 This is a very simple bot that just displays any gotten updates,
 then replies it to that chat.
@@ -38,7 +30,7 @@ package main
 import (
 	"log"
 
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	tgbotapi "github.com/OvyFlash/telegram-bot-api/v6"
 )
 
 func main() {
@@ -79,7 +71,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/OvyFlash/telegram-bot-api/v6"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-telegram-bot-api/telegram-bot-api/v5
+module github.com/OvyFlash/telegram-bot-api/v6
 
-go 1.16
+go 1.23


### PR DESCRIPTION
the PR sets the module to github.com/OvyFlash/telegram-bot-api/v6 and update go version to the supported one (1.23)

Please note: tests are failing due to hardcoded `TestToken` and other details defined in `bot_test.go`. Extracting all of those to Action's secrets will allow testing of forks, but this change is unrelated to the module update.

See #34 for details 