### PR TITLE
Custom file endpoint

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -282,7 +282,7 @@ func (bot *BotAPI) GetFile(config FileConfig, fileEndpoint ...string) (File, err
 		endpointToUse = fileEndpoint[0]
 	}
 
-	resp, err := bot.MakeRequest(fmt.Sprintf(endpointToUse, bot.Token, "getFile"), config.params()) //Изменено: используем MakeRequest с новым endpoint
+	resp, err := bot.MakeRequest(fmt.Sprintf(endpointToUse, bot.Token, "getFile"), config.params())
 	if err != nil {
 		return File{}, err
 	}


### PR DESCRIPTION
Now it should work like this:
```golang
bot, err := tgbotapi.NewBotAPIWithClient("YOUR_TOKEN", "https://your-custom-api.example.com/bot%s/%s", "https://your-custom-file-api.example.com/file/bot%s/%s", &http.Client{})
file, err := bot.GetFile(tgbotapi.FileConfig{FileID: "fileID"}, "https://your-custom-file-api.example.com/file/bot%s/%s")
```

I'm not sure if this work, I didn't edit tests. Pls check.