### PR TITLE
Add Forum Topic Management Methods

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -786,6 +786,19 @@ func (bot *BotAPI) GetMyDefaultAdministratorRights(config GetMyDefaultAdministra
 	return rights, err
 }
 
+// CreateForumTopic creates a topic in a forum supergroup chat.
+func (bot *BotAPI) CreateForumTopic(config CreateForumTopicConfig) (ForumTopic, error) {
+	var topic ForumTopic
+
+	resp, err := bot.Request(config)
+	if err != nil {
+		return topic, err
+	}
+
+	err = json.Unmarshal(resp.Result, &topic)
+	return topic, err
+}
+
 // EscapeText takes an input text and escape Telegram markup symbols.
 // In this way we can send a text without being afraid of having to escape the characters manually.
 // Note that you don't have to include the formatting style in the input text, or it will be escaped too.

--- a/helper_methods.go
+++ b/helper_methods.go
@@ -71,7 +71,7 @@ func NewVerifyChat(chat ChatConfig, customDescription string) VerifyChatConfig {
 	}
 }
 
-// NewRemoveUserVerification removes verification from a user who is currently 
+// NewRemoveUserVerification removes verification from a user who is currently
 // verified on behalf of the organization represented by the bot.
 func NewRemoveUserVerification(userID int64) RemoveUserVerificationConfig {
 	return RemoveUserVerificationConfig{
@@ -1334,5 +1334,26 @@ func NewInputPaidMediaVideo(media *InputMediaVideo) InputPaidMedia {
 	return InputPaidMedia{
 		Type:  "video",
 		Media: media,
+	}
+}
+
+// NewCreateForumTopicConfig creates a topic in a forum supergroup chat.
+func NewCreateForumTopicConfig(chatID int64, topicName string) CreateForumTopicConfig {
+	return CreateForumTopicConfig{
+		ChatConfig: ChatConfig{
+			ChatID: chatID,
+		},
+		Name: topicName,
+	}
+}
+
+// NewEditForumTopicConfig edit name and icon of a topic in a forum supergroup chat.
+func NewEditForumTopicConfig(chatID, threadID int64, topicName string) EditForumTopicConfig {
+	return EditForumTopicConfig{
+		BaseForum: BaseForum{
+			ChatConfig:      ChatConfig{ChatID: chatID},
+			MessageThreadID: int(threadID),
+		},
+		Name: topicName,
 	}
 }


### PR DESCRIPTION
Added Methods
- CreateForumTopic(config CreateForumTopicConfig)
        Creates a new topic in a forum supergroup chat.
- NewCreateForumTopicConfig(chatID int64, topicName string) CreateForumTopicConfig
        Helper function to generate the configuration for creating a forum topic.
- NewEditForumTopicConfig(chatID, threadID int64, topicName string) EditForumTopicConfig
        Helper function to generate the configuration for editing a forum topic’s name and icon.
