### PR TITLE
Add width/height params for video and animation

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -749,6 +749,8 @@ type VideoConfig struct {
 	BaseSpoiler
 	Thumb                 RequestFileData
 	Duration              int
+	Width                 int
+	Height                int
 	Cover                 RequestFileData
 	StartTimestamp        int64
 	Caption               string
@@ -765,6 +767,8 @@ func (config VideoConfig) params() (Params, error) {
 	}
 
 	params.AddNonZero("duration", config.Duration)
+	params.AddNonZero("width", config.Width)
+	params.AddNonZero("height", config.Height)
 	params.AddNonZero64("start_timestamp", config.StartTimestamp)
 	params.AddNonEmpty("caption", config.Caption)
 	params.AddNonEmpty("parse_mode", config.ParseMode)
@@ -801,6 +805,8 @@ type AnimationConfig struct {
 	BaseFile
 	BaseSpoiler
 	Duration              int
+	Width                 int
+	Height                int
 	Thumb                 RequestFileData
 	Caption               string
 	ParseMode             string
@@ -815,6 +821,8 @@ func (config AnimationConfig) params() (Params, error) {
 	}
 
 	params.AddNonZero("duration", config.Duration)
+	params.AddNonZero("width", config.Width)
+	params.AddNonZero("height", config.Height)
 	params.AddNonEmpty("caption", config.Caption)
 	params.AddNonEmpty("parse_mode", config.ParseMode)
 	params.AddBool("show_caption_above_media", config.ShowCaptionAboveMedia)

--- a/configs_test.go
+++ b/configs_test.go
@@ -146,6 +146,50 @@ func TestSendLivePhotoConfigUploadSerialization(t *testing.T) {
 	}
 }
 
+func TestVideoAndAnimationConfigDimensionParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         func() (Params, error)
+		expectedWidth  string
+		expectedHeight string
+	}{
+		{
+			name: "video",
+			params: func() (Params, error) {
+				config := NewVideo(1, FileID("video-file-id"))
+				config.Width = 1920
+				config.Height = 1080
+				return config.params()
+			},
+			expectedWidth:  "1920",
+			expectedHeight: "1080",
+		},
+		{
+			name: "animation",
+			params: func() (Params, error) {
+				config := NewAnimation(1, FileID("animation-file-id"))
+				config.Width = 640
+				config.Height = 360
+				return config.params()
+			},
+			expectedWidth:  "640",
+			expectedHeight: "360",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := tt.params()
+			if err != nil {
+				t.Fatalf("params failed: %v", err)
+			}
+			if params["width"] != tt.expectedWidth || params["height"] != tt.expectedHeight {
+				t.Fatalf("dimension params mismatch: %#v", params)
+			}
+		})
+	}
+}
+
 func TestSendPollConfigBotAPI10MediaSerialization(t *testing.T) {
 	optionMedia := &InputMediaSticker{
 		Type:  "sticker",


### PR DESCRIPTION
Add optional parameters for width and height to video and animation configs. These can assist the backend with videos it does not parse to properly deliver dimensions to clients.