### PR TITLE
NewEphemeralMessage

### DIFF
--- a/bot_api_10_2_test.go
+++ b/bot_api_10_2_test.go
@@ -152,6 +152,23 @@ func TestBotAPI102ReplyParametersIdentifiers(t *testing.T) {
 	}
 }
 
+func TestBotAPI102NewEphemeralMessageDirectAdminParams(t *testing.T) {
+	config := NewEphemeralMessage(-1001, 42, "private")
+	params, err := config.params()
+	if err != nil {
+		t.Fatalf("params: %v", err)
+	}
+	if params["chat_id"] != "-1001" || params["receiver_user_id"] != "42" || params["text"] != "private" {
+		t.Fatalf("direct admin ephemeral params mismatch: %#v", params)
+	}
+	if _, ok := params["callback_query_id"]; ok {
+		t.Fatalf("direct admin request unexpectedly contains callback query: %#v", params)
+	}
+	if _, ok := params["reply_parameters"]; ok {
+		t.Fatalf("direct admin request unexpectedly contains reply parameters: %#v", params)
+	}
+}
+
 func TestBotAPI102EphemeralSendParams(t *testing.T) {
 	message := NewMessage(1, "text")
 	message.ReceiverUserID, message.CallbackQueryID = 42, "callback"

--- a/helper_methods.go
+++ b/helper_methods.go
@@ -933,7 +933,7 @@ func NewEphemeralMessage(chatID int64, receiverID int64, text string) MessageCon
 		},
 		Text:           text,
 		ReceiverUserID: receiverID,
-		LinkPreviewOptions: tgbotapi.LinkPreviewOptions{
+		LinkPreviewOptions: LinkPreviewOptions{
 			IsDisabled: false,
 		},
 	}

--- a/helper_methods.go
+++ b/helper_methods.go
@@ -921,24 +921,16 @@ func newBaseEphemeralMessage(chatID, receiverUserID int64, ephemeralMessageID in
 	}
 }
 
-// NewEphemeralMessage creates a new EphemeralMessage.
+// NewEphemeralMessage creates a text message visible only to receiverUserID.
 //
-// chatID is where to send it, receiverID is userID, text is the message text.
-func NewEphemeralMessage(chatID int64, receiverID int64, text string) MessageConfig {
-	return MessageConfig{
-		BaseChat: BaseChat{
-			ChatConfig: ChatConfig{
-				ChatID: chatID,
-			},
-		},
-		Text:           text,
-		ReceiverUserID: receiverID,
-		LinkPreviewOptions: LinkPreviewOptions{
-			IsDisabled: false,
-		},
-	}
+// Bot administrators can send the returned config directly. Other bots must
+// additionally set CallbackQueryID or ReplyParameters.EphemeralMessageID
+// within 15 seconds of an eligible action.
+func NewEphemeralMessage(chatID, receiverUserID int64, text string) MessageConfig {
+	config := NewMessage(chatID, text)
+	config.ReceiverUserID = receiverUserID
+	return config
 }
-
 
 // NewEditEphemeralMessageText creates a request to edit ephemeral message text.
 func NewEditEphemeralMessageText(chatID, receiverUserID int64, ephemeralMessageID int, text string) EditEphemeralMessageTextConfig {

--- a/helper_methods.go
+++ b/helper_methods.go
@@ -921,6 +921,25 @@ func newBaseEphemeralMessage(chatID, receiverUserID int64, ephemeralMessageID in
 	}
 }
 
+// NewEphemeralMessage creates a new EphemeralMessage.
+//
+// chatID is where to send it, receiverID is userID, text is the message text.
+func NewEphemeralMessage(chatID int64, receiverID int64, text string) MessageConfig {
+	return MessageConfig{
+		BaseChat: BaseChat{
+			ChatConfig: ChatConfig{
+				ChatID: chatID,
+			},
+		},
+		Text:           text,
+		ReceiverUserID: receiverID,
+		LinkPreviewOptions: tgbotapi.LinkPreviewOptions{
+			IsDisabled: false,
+		},
+	}
+}
+
+
 // NewEditEphemeralMessageText creates a request to edit ephemeral message text.
 func NewEditEphemeralMessageText(chatID, receiverUserID int64, ephemeralMessageID int, text string) EditEphemeralMessageTextConfig {
 	return EditEphemeralMessageTextConfig{


### PR DESCRIPTION
> If the bot is a chat administrator, it can send an ephemeral message to any non-bot member of the chat at any time without needing to specify a callback_query_id or reply_parameters.ephemeral_message_id. In this case, the message may be delivered across multiple active client applications of the user, but is regardless not guaranteed to be delivered to any of them.

Direct version
curl -s -X POST "https://api.telegram.org/bot<botToken>/sendMessage" \
 -d chat_id=<chat_id> \
 -d text="New Ephemeral" \
 -d receiver_user_id=<user_id>