### PR TITLE
Add ephemeral parameters to sendLivePhoto

### DIFF
--- a/bot_api_10_2_test.go
+++ b/bot_api_10_2_test.go
@@ -180,6 +180,8 @@ func TestBotAPI102EphemeralSendParams(t *testing.T) {
 	document.ReceiverUserID, document.CallbackQueryID = 42, "callback"
 	photo := NewPhoto(1, FileID("photo"))
 	photo.ReceiverUserID, photo.CallbackQueryID = 42, "callback"
+	livePhoto := NewLivePhoto(1, FileID("live-photo"), FileID("photo"))
+	livePhoto.ReceiverUserID, livePhoto.CallbackQueryID = 42, "callback"
 	sticker := NewSticker(1, FileID("sticker"))
 	sticker.ReceiverUserID, sticker.CallbackQueryID = 42, "callback"
 	video := NewVideo(1, FileID("video"))
@@ -204,6 +206,7 @@ func TestBotAPI102EphemeralSendParams(t *testing.T) {
 		{method: "sendAudio", config: audio},
 		{method: "sendDocument", config: document},
 		{method: "sendPhoto", config: photo},
+		{method: "sendLivePhoto", config: livePhoto},
 		{method: "sendSticker", config: sticker},
 		{method: "sendVideo", config: video},
 		{method: "sendVideoNote", config: videoNote},

--- a/configs.go
+++ b/configs.go
@@ -628,6 +628,8 @@ type SendLivePhotoConfig struct {
 	ParseMode             string
 	CaptionEntities       []MessageEntity
 	ShowCaptionAboveMedia bool
+	ReceiverUserID        int64
+	CallbackQueryID       string
 }
 
 func (config SendLivePhotoConfig) params() (Params, error) {
@@ -639,6 +641,8 @@ func (config SendLivePhotoConfig) params() (Params, error) {
 	params.AddNonEmpty("caption", config.Caption)
 	params.AddNonEmpty("parse_mode", config.ParseMode)
 	params.AddBool("show_caption_above_media", config.ShowCaptionAboveMedia)
+	params.AddNonZero64("receiver_user_id", config.ReceiverUserID)
+	params.AddNonEmpty("callback_query_id", config.CallbackQueryID)
 	if err = params.AddInterface("caption_entities", config.CaptionEntities); err != nil {
 		return params, err
 	}


### PR DESCRIPTION
## Summary
- add optional ReceiverUserID and CallbackQueryID fields to SendLivePhotoConfig
- serialize them as receiver_user_id and callback_query_id
- cover sendLivePhoto in the Bot API 10.2 ephemeral-send contract test

## Verification
- go test -run TestBotAPI102EphemeralSendParams -count=1 -v .
- go test -race -shuffle=on -count=1 -timeout=10m ./...
- go vet ./...
- go test -tags api_parity -run ^TestAPIParity -v .
- git diff --check